### PR TITLE
Fix end event not propagated on a glob sometimes.

### DIFF
--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -307,7 +307,9 @@ module.exports = {
 
 		if ( this.noMlsd ) return this.list( path, cb );
 
-		this.mlsd( path, onMlsd );
+		setImmediate(function() {
+			self.mlsd( path, onMlsd );
+		});
 
 		function onMlsd( err, files ) {
 


### PR DESCRIPTION
Hi, many thanks for this project!

Bumped into a case where executing
```
conn1.src(glob1, { buffer: false, read: false })
      ... wait for the end event no problem...
// now reuse the same connection.
conn1.src('*.csv' { buffer: false, read: false });
// depending on the value of glob1 we might never receive the end event.
```
When glob1 = '*.csv', it always works.
When glob1 = 'times.csv' it never completes.

glob.js emits an 'end' event on a passthrough stream.

But that code looks like it could behave synchroneously - maybe with the cache;
the passthrough has not been placed in the pipe
yet and therefore the end event is not propagated.

Adding this setImmediate guarantees that by the time we emit end, the pipeline is connected.
It does fix my test units.

My test setup is using nodeftp although. I need to find some other co-workers to see if they get the same issue on their machines or if it is just me.