### PR TITLE
Vinyl's file method `pipe` is being removed

### DIFF
--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -26,7 +26,11 @@ module.exports = {
 
 		}
 
-		file.pipe( stream, { end: true } );
+		if ( file.isStream() ) {
+			file.contents.pipe( stream );
+		} else if ( file.isBuffer() ) {
+			stream.end( file.contents );
+		}
 
 		// ensure that parent directory exists
 		self.mkdirp( Path.dirname( path ), onParent );


### PR DESCRIPTION
I stumbled on the fact that vinyl removed the pipe method 4 days ago.
gulpjs/vinyl#107

This the change required to cope with that removal.

Note: if the gulp maintainers are reading this issue I dont think it is a bad thing: I was mocking a vinyl File and found out I needed to implement the pipe method for my mock to work with vinyl-ftp. Once this change is released I wont need to code the pipe method anymore.

Cheers!