### PR TITLE
Edit ftp.js add check type of file in VinylFiles method.

### DIFF
--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -432,7 +432,7 @@ module.exports = {
 
 		return files.filter( function ( file ) {
 
-			return file.name !== '.' && file.name !== '..';
+			return file.name !== '.' && file.name !== '..' && typeof(file) !== 'string';
 
 		} ).map( function ( file ) {
 


### PR DESCRIPTION
In this pull request I've resolved a problem, that occured. This statement eliminates the error that I've receiving, when instead of files in array appears wierd strings like '\u0001\u0001\u0005'. TypeError: Path must be a string. Received undefined #87