### PR TITLE
Fix bug: in glob.js scan(), after writing files, properly end writabl…

### DIFF
--- a/lib/glob.js
+++ b/lib/glob.js
@@ -50,7 +50,7 @@ function glob( globs, options ) {
 
 			--scanning;
 
-			if ( scanning === 0 ) stream.emit( 'end' );
+			if ( scanning === 0 ) stream.end();
 
 		}
 


### PR DESCRIPTION
…e stream by calling stream.end()

- previous code `stream.emit( 'end' )` would cause cut off src() downloads after 16 files, or more accurately, after stream.highWaterMark files